### PR TITLE
Rename pages

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -45,8 +45,8 @@ const Layout = ({ title = '', description, children }: LayoutProps) => {
 
             <Navbar.Nav>
               <Navbar.Nav.Link href="/about">About</Navbar.Nav.Link>
-              <Navbar.Nav.Link href="/guides">Guides</Navbar.Nav.Link>
-              <Navbar.Nav.Link href="/works">Works</Navbar.Nav.Link>
+              <Navbar.Nav.Link href="/articles">Articles</Navbar.Nav.Link>
+              <Navbar.Nav.Link href="/projects">Projects</Navbar.Nav.Link>
               <Navbar.Nav.ThemeChanger />
             </Navbar.Nav>
           </Navbar>

--- a/src/pages/articles.tsx
+++ b/src/pages/articles.tsx
@@ -4,26 +4,26 @@ import Intro from '@/components/Intro'
 import Layout from '@/components/Layout'
 import SubHeading from '@/components/SubHeading'
 
-const Works = () => {
+const Guides = () => {
   return (
     <Layout
-      title="Works"
-      description="A list of projects I was responsible or part of."
+      title="Articles"
+      description="Thoughts and tips about accessibility in data visualization."
     >
       <Intro>
         <DisplayHeading>
           <GradientText
             className="glow-lg glow-opacity-25 dark:glow-opacity-30"
-            data-content="Works"
+            data-content="Articles"
           >
-            Works
+            Articles
           </GradientText>
         </DisplayHeading>
 
-        <SubHeading>A curated list of projects</SubHeading>
+        <SubHeading>Make information accessible</SubHeading>
       </Intro>
     </Layout>
   )
 }
 
-export default Works
+export default Guides

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -47,7 +47,7 @@ const Home = () => {
         it in data visualization.{' '}
         <span className="block">
           <GradientLink
-            href="/guides"
+            href="/articles"
             className="inline-block text-lg"
             textContent="Accessible dataviz →"
           >
@@ -70,7 +70,7 @@ const Home = () => {
         .{' '}
         <span className="block">
           <GradientLink
-            href="/works"
+            href="/projects"
             className="inline-block text-lg"
             textContent="Check our works →"
           >

--- a/src/pages/projects.tsx
+++ b/src/pages/projects.tsx
@@ -4,26 +4,26 @@ import Intro from '@/components/Intro'
 import Layout from '@/components/Layout'
 import SubHeading from '@/components/SubHeading'
 
-const Guides = () => {
+const Works = () => {
   return (
     <Layout
-      title="Guides"
-      description="Thoughts and tips about accessibility in data visualization."
+      title="Projects"
+      description="A list of works I was responsible or part of and personal projects."
     >
       <Intro>
         <DisplayHeading>
           <GradientText
             className="glow-lg glow-opacity-25 dark:glow-opacity-30"
-            data-content="Guides"
+            data-content="Projects"
           >
-            Guides
+            Projects
           </GradientText>
         </DisplayHeading>
 
-        <SubHeading>Make information accessible</SubHeading>
+        <SubHeading>A curated list of works</SubHeading>
       </Intro>
     </Layout>
   )
 }
 
-export default Guides
+export default Works


### PR DESCRIPTION
I think the new names are better.

‘Guides’ looks like a step-by-step tutorial, while ‘Articles’ are more like thoughts on solutions.

Also, ‘Projects’ seems more generic.