### PR TITLE
Fix theme changer button icon

### DIFF
--- a/src/components/NavbarNavThemeChanger.tsx
+++ b/src/components/NavbarNavThemeChanger.tsx
@@ -10,7 +10,7 @@ const NavbarNavThemeChanger = ({
   className = '',
   ...htmlButtonProps
 }: NavbarNavThemeChangerProps) => {
-  const { theme, setTheme } = useTheme()
+  const { resolvedTheme, setTheme } = useTheme()
 
   const { mounted } = useContext(AppContext)
 
@@ -27,10 +27,10 @@ const NavbarNavThemeChanger = ({
           dark:focus-visible:bg-neutral-700
           sm-base:p-3
         `)}
-        onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+        onClick={() => setTheme(resolvedTheme === 'light' ? 'dark' : 'light')}
         aria-label={
           mounted
-            ? `Switch to ${theme === 'light' ? 'dark' : 'light'} theme`
+            ? `Switch to ${resolvedTheme === 'light' ? 'dark' : 'light'} theme`
             : 'Toggle theme'
         }
         {...htmlButtonProps}
@@ -97,7 +97,7 @@ const NavbarNavThemeChanger = ({
           {mounted ? (
             <use
               xlinkHref={`#color-mode-toggle-icon-${
-                theme === 'light' ? 'dark' : 'light'
+                resolvedTheme === 'light' ? 'dark' : 'light'
               }`}
             />
           ) : (


### PR DESCRIPTION
After upgrading to v0.0.14, [next-themes](https://github.com/pacocoursey/next-themes) defaults to system theme.

Use `resolvedTheme` to get the real value.

Closes #7
Fix #28